### PR TITLE
Fix puppeteer error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ const parseErrors = async (page) => {
 };
 
 (async () => {
-  const browser = await puppeteer.launch({ headless: true });
+  const browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox'] });
   const page = await browser.newPage();
   const definitionFilePath = path.join(
     process.env.GITHUB_WORKSPACE,


### PR DESCRIPTION
# Description

Add --no-sandbox arg when launching puppeteer
I'm facing with the error when running this action suddenly. It related to [this](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox) and I updated argument accordingly

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
