### PR TITLE
Allow overriding action path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,12 +12,17 @@ inputs:
   ignore-error:
     description: JavaScript file containing predicate for determining if the error should be ignored or not
     required: false
+  action-path:
+    description: Github action folder path
+    required: false
+    default: ${{ github.action_path }}
+
 runs:
   using: composite
   steps:
-    - run: cd ${{ github.action_path }} && npm install
+    - run: cd ${{ inputs.action-path }} && npm install
       shell: bash
-    - run: cd ${{ github.action_path }} && SWAGGER_EDITOR_URL=${{ inputs.swagger-editor-url }} DEFINITION_FILE=${{ inputs.definition-file }} IGNORE_ERROR=${{ inputs.ignore-error }} node src/index.js
+    - run: cd ${{ inputs.action-path }} && SWAGGER_EDITOR_URL=${{ inputs.swagger-editor-url }} DEFINITION_FILE=${{ inputs.definition-file }} IGNORE_ERROR=${{ inputs.ignore-error }} node src/index.js
       shell: bash
 branding:
   icon: 'file-text'

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/swaggerexpert/swagger-editor-validate.git"
+    "url": "https://github.com/etam-pro/swagger-editor-validate.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/swaggerexpert/swagger-editor-validate/issues"
+    "url": "https://github.com/etam-pro/swagger-editor-validate/issues"
   },
-  "homepage": "https://github.com/swaggerexpert/swagger-editor-validate#readme"
+  "homepage": "https://github.com/etam-pro/swagger-editor-validate#readme"
 }


### PR DESCRIPTION
# Description

The base branch is using `github.action_path` as location, which is not necessarily always pointing to the right location (See [issue](https://github.com/actions/runner/issues/716))

This PR attempts to address the issue by allowing an override to the location by taking in an extra optional input.



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Tested with CI

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
