### PR TITLE
Update GitHub Action versions; add a Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,13 @@ updates:
       prefix: "chore"
       include: "scope"
     open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
     name: Swagger Editor Validate - Repo integrity
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
       - run: npm ci
@@ -35,7 +35,7 @@ jobs:
           - 80:8080
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Validate OpenAPI definition
         uses: swaggerexpert/swagger-editor-validate@master
         with:
@@ -47,7 +47,7 @@ jobs:
     name: Swagger Editor Validate Remote
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Validate OpenAPI definition
         uses: swaggerexpert/swagger-editor-validate@master
         with:
@@ -58,7 +58,7 @@ jobs:
     name: Swagger Editor Validate
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Validate OpenAPI definition
         continue-on-error: true
         id: validate
@@ -77,7 +77,7 @@ jobs:
     name: Swagger Editor Ignore Errors
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Validate OpenAPI definition
         uses: swaggerexpert/swagger-editor-validate@master
         with:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
     name: Swagger Editor Validator Remote
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Validate OpenAPI definition
         uses: swaggerexpert/swagger-editor-validate@v1
         with:
@@ -86,7 +86,7 @@ jobs:
           - 80:8080
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Validate OpenAPI definition
         uses: swaggerexpert/swagger-editor-validate@v1
         with:


### PR DESCRIPTION
# Description

All GitHub Action versions are very out-of-date.

This PR addresses the issue in two ways:

1. It manually updates all action versions (`actions/checkout@v2` and `actions/setup-node@v2`) to the latest available versions (`@v4` for both), and updates the README as well.

   No known breaking changes were introduced between v2 and v4 releases.

2. It introduces a Dependabot config for maintaining GitHub Action versions. The frequency is set to "monthly", and the updates are grouped so that if there are two updates available, they will be batched together in the same PR.

# How Has This Been Tested?

It hasn't been tested. It will be when CI runs against this PR.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Note that this change is a superset of #680.